### PR TITLE
Update district selector and add temp district page

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -22,6 +22,7 @@ import drawerReducer from 'reducers/drawer'
 import ContextStore, { drawerInitialState } from 'ContextStore'
 import withTracker from './WithTracker'
 import SearchDrawer from 'components/pages/SearchDrawer'
+import DistrictOverviewPage from 'components/pages/district/overview'
 
 const client = new ApolloClient({
   uri: process.env.REACT_APP_GRAPHQL_URI,
@@ -99,6 +100,10 @@ const App = props => {
                     <Route
                       path="/district/2019/tags/:tag"
                       component={withTracker(DistrictListPage)}
+                    />
+                    <Route
+                      path="/district/2019/:code(\w{1})"
+                      component={withTracker(DistrictOverviewPage)}
                     />
                     <Route
                       path="/district/2019/:code"

--- a/web/src/components/district/DCCAOverview.js
+++ b/web/src/components/district/DCCAOverview.js
@@ -14,9 +14,12 @@ import Box from '@material-ui/core/Box'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp'
 import Breadcrumbs from '@material-ui/core/Breadcrumbs'
-// import Link from '@material-ui/core/Link'
+import Link from '@material-ui/core/Link'
 import NavigateNextIcon from '@material-ui/icons/NavigateNext'
-import { getDistrictListUriFromTag } from 'utils/helper'
+import {
+  getDistrictListUriFromTag,
+  getDistrictOverviewUriFromTag,
+} from 'utils/helper'
 import { withRouter } from 'react-router-dom'
 import { SuccessText, FailureText } from 'components/atoms/Text'
 
@@ -70,7 +73,15 @@ class DCCAOverview extends Component {
   }
 
   render() {
-    const { name_zh, year, code, dc_name_zh, tags, voterData } = this.props
+    const {
+      name_zh,
+      year,
+      code,
+      dc_code,
+      dc_name_zh,
+      tags,
+      voterData,
+    } = this.props
     const sortedTags = tags.sort((a, b) =>
       a.type === 'boundary' ? -1 : a.type === b.type ? 0 : 1
     )
@@ -83,8 +94,8 @@ class DCCAOverview extends Component {
         <Rows>
           <Columns>
             <Box flexGrow={1}>
-              {/* 
-                wingkwong 20190927: 
+              {/*
+                wingkwong 20190927:
                   currently the pages are not avilable. Use below Breadcrumbs once they are ready.
               */}
               {/* <Breadcrumbs separator={<NavigateNextIcon fontSize="small" />} aria-label="breadcrumb">
@@ -98,8 +109,8 @@ class DCCAOverview extends Component {
                   {name_zh} {code}
                 </Typography>
             </Breadcrumbs> */}
-              {/* 
-                wingkwong 20190927: 
+              {/*
+                wingkwong 20190927:
                   currently the pages are not avilable. Remove below Breadcrumbs once they are ready.
               */}
               <Breadcrumbs
@@ -107,7 +118,15 @@ class DCCAOverview extends Component {
                 aria-label="breadcrumb"
               >
                 <Typography color="textPrimary"> {year}</Typography>
-                <Typography color="textPrimary">{dc_name_zh}</Typography>
+                <Link
+                  onClick={() => {
+                    this.props.history.push(
+                      getDistrictOverviewUriFromTag(dc_code)
+                    )
+                  }}
+                >
+                  <Typography color="textPrimary">{dc_name_zh}</Typography>
+                </Link>
                 <Typography color="textPrimary">
                   {name_zh} {code}
                 </Typography>

--- a/web/src/components/molecules/DistrictSelector.js
+++ b/web/src/components/molecules/DistrictSelector.js
@@ -13,7 +13,9 @@ import { withRouter } from 'react-router-dom'
 import { Query } from 'react-apollo'
 import { QUERY_GET_AREA } from 'queries/gql'
 import Grid from '@material-ui/core/Grid'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import AreaTabs from 'components/organisms/AreaTabs'
+import { getDistrictOverviewUriFromTag } from 'utils/helper'
 
 const Container = styled.div`
   && {
@@ -33,7 +35,7 @@ const DistrictContainer = styled(Button)`
 
 const DistrictExpansionPanel = styled(ExpansionPanel)`
   && {
-    margin: 0;
+    margin: 5px 0;
   }
 `
 
@@ -48,9 +50,9 @@ const DistrictExpansionPanelDetails = styled(ExpansionPanelDetails)`
   }
 `
 
-const DistrictGrid = styled(Grid)`
+const DistrictWrapper = styled(Grid)`
   && {
-    margin: 5px;
+    margin: 0 5px;
   }
 `
 
@@ -62,13 +64,26 @@ const DistrictSelector = props => {
   const renderDCCA = district => {
     return (
       <div>
+        <DistrictContainer
+          key={district.dc_code}
+          onClick={() => {
+            dispatch({ type: DRAWER_CLOSE })
+            props.history.push(`/district/2019/${district.dc_code}`)
+          }}
+          color="secondary"
+        >
+          <Typography variant="h5">
+            全{district.dc_name_zh}
+            {district.dc_name_zh.includes('區') ? '' : '區'}
+          </Typography>
+        </DistrictContainer>
         {district.constituencies.map(c => {
           return (
             <DistrictContainer
               key={c.code}
               onClick={() => {
                 dispatch({ type: DRAWER_CLOSE })
-                props.history.push(`/district/2019/${c.code}`)
+                getDistrictOverviewUriFromTag(c.code)
               }}
               color="secondary"
             >
@@ -80,27 +95,25 @@ const DistrictSelector = props => {
     )
   }
 
-  // TODO Change to use 2 columns design
   const renderArea = area => {
-    return _.chunk(area.districts, 1).map((row, index) => (
-      <Grid container wrap="nowrap" key={`districts-row-${index}`}>
-        {row.map(d => (
-          <DistrictGrid item xs={12} key={`district-item-${d.dc_code}`}>
-            <DistrictExpansionPanel key={`district-panel-${d.dc_code}`}>
-              <DistrictExpansionPanelSummary
-                aria-controls="panel1a-content"
-                id="panel1a-header"
-              >
-                <Typography variant="h5">{d.dc_name_zh}</Typography>
-              </DistrictExpansionPanelSummary>
-              <DistrictExpansionPanelDetails>
-                {renderDCCA(d)}
-              </DistrictExpansionPanelDetails>
-            </DistrictExpansionPanel>
-          </DistrictGrid>
+    return (
+      <DistrictWrapper>
+        {area.districts.map((d, index) => (
+          <DistrictExpansionPanel key={`district-panel-${d.dc_code}`}>
+            <DistrictExpansionPanelSummary
+              aria-controls="panel1a-content"
+              id="panel1a-header"
+              expandIcon={<ExpandMoreIcon />}
+            >
+              <Typography variant="h5">{d.dc_name_zh}</Typography>
+            </DistrictExpansionPanelSummary>
+            <DistrictExpansionPanelDetails>
+              {renderDCCA(d)}
+            </DistrictExpansionPanelDetails>
+          </DistrictExpansionPanel>
         ))}
-      </Grid>
-    ))
+      </DistrictWrapper>
+    )
   }
 
   return (

--- a/web/src/components/molecules/DistrictSelector.js
+++ b/web/src/components/molecules/DistrictSelector.js
@@ -128,7 +128,7 @@ const DistrictSelector = props => {
           const areaNames = areas.map(a => a.area_name_zh)
 
           return (
-            <AreaTabs titles={areaNames}>
+            <AreaTabs titles={areaNames} expanded={props.expanded}>
               {areasWithDistricts.map(a => {
                 return renderArea(a)
               })}

--- a/web/src/components/organisms/AreaTabs.js
+++ b/web/src/components/organisms/AreaTabs.js
@@ -37,8 +37,10 @@ TabPanel.propTypes = {
 }
 
 export default function AreaTabs(props) {
-  const [selectedTab, setSelectedTab] = React.useState(false)
-  const [expanded, setExpanded] = React.useState(false)
+  const [selectedTab, setSelectedTab] = React.useState(
+    props.expanded ? 0 : false
+  )
+  const [expanded, setExpanded] = React.useState(props.expanded)
   const { titles, children } = props
 
   function handleChange(event, newValue) {

--- a/web/src/components/organisms/AreaTabs.js
+++ b/web/src/components/organisms/AreaTabs.js
@@ -55,11 +55,7 @@ export default function AreaTabs(props) {
 
   return (
     <>
-      <AreasTabs
-        value={selectedTab}
-        onChange={handleChange}
-        variant="fullWidth"
-      >
+      <AreasTabs value={selectedTab} onChange={handleChange} centered>
         {titles.map((title, index) => (
           <AreasTab
             label={title}

--- a/web/src/components/organisms/Footer.js
+++ b/web/src/components/organisms/Footer.js
@@ -16,6 +16,10 @@ const StyledFooter = styled(Box)`
   }
 `
 
+const StyledTypography = styled(Typography)`
+  padding: 0 16px;
+`
+
 const StyledDivider = styled(Divider)`
   && {
     margin-top: 16px;
@@ -33,6 +37,7 @@ const LinkBox = styled(Box)`
     margin-left: 16px;
     margin-top: 16px;
     word-break: keep-all;
+    overflow: hidden;
   }
 `
 
@@ -40,16 +45,16 @@ function Footer(props) {
   return (
     <>
       <StyledFooter>
-        <Typography variant="body2" gutterBottom>
+        <StyledTypography variant="body2" gutterBottom>
           本網站所刊載資訊全為公開資料，歸納自選舉管理委員會丶選舉事務處丶政府統計處丶各區區議會網站及
           <a href="https://github.com/initiummedia/hk_district_council_election">
             端傳媒
           </a>
           ，刊載前已盡力確保資料真確性，如有建議或錯漏，請按下方連結回報。
-        </Typography>
-        <Typography variant="body2">
+        </StyledTypography>
+        <StyledTypography variant="body2">
           本網站與任何2019年區議會選舉候選人或其助選成員無關，刊載資料目的非為促使或阻礙任何候選人在選舉中當選。
-        </Typography>
+        </StyledTypography>
         <StyledDivider />
         <Columns>
           <LinkBox>

--- a/web/src/components/organisms/SearchTab.js
+++ b/web/src/components/organisms/SearchTab.js
@@ -101,7 +101,7 @@ function SearchTab(props) {
   function renderSearchDistrict() {
     return (
       <ContentRowContainer>
-        <DistrictSelector />
+        <DistrictSelector expanded={false} />
         <AddressSearchContainer>
           <AddressSearcher handleAddressSelected={handleAddressSelected} />
         </AddressSearchContainer>

--- a/web/src/components/organisms/search-drawer/SearchMenu.js
+++ b/web/src/components/organisms/search-drawer/SearchMenu.js
@@ -117,7 +117,7 @@ const SearchMenu = props => {
   }
 
   function renderDistrictSelector() {
-    return <DistrictSelector />
+    return <DistrictSelector expanded={true} />
   }
 
   return (

--- a/web/src/components/pages/battleground/index.js
+++ b/web/src/components/pages/battleground/index.js
@@ -88,7 +88,8 @@ class BattleGroundPage extends Component {
               <>
                 <DCCAOverview
                   year={year}
-                  name_zh={district.name_zh}
+                  dc_code={district.district.dc_code}
+                  dc_name_zh={district.district.dc_name_zh}
                   dc_name_zh={district.district.dc_name_zh}
                   code={district.code}
                   tags={district.tags}

--- a/web/src/components/pages/district/overview.js
+++ b/web/src/components/pages/district/overview.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Query } from 'react-apollo'
+import { QUERY_GET_DISTRICT } from 'queries/gql'
+import ConstituencyCard from 'components/organisms/ConstituencyCard'
+import { Typography } from '@material-ui/core'
+import Paper from '@material-ui/core/Paper'
+import { Loading } from 'components/atoms/Loading'
+
+const Container = styled(Paper)`
+  && {
+    width: 100%;
+    padding: 16px;
+    box-shadow: none;
+  }
+`
+
+const DistrictOverviewPage = props => {
+  const {
+    match: {
+      params: { code },
+    },
+  } = props
+
+  return (
+    <Query query={QUERY_GET_DISTRICT} variables={{ code, year: 2019 }}>
+      {({ loading, error, data }) => {
+        if (loading) return <Loading />
+        if (error) return `Error! ${error}`
+
+        const district = data.dcd_districts[0]
+
+        return (
+          <>
+            <Container>
+              <Typography variant="h4">{`${district.dc_name_zh}：${district.constituencies.length}個選區`}</Typography>
+            </Container>
+            <Container>
+              {district.constituencies.map(c => (
+                <ConstituencyCard key={c.id} constituency={c} />
+              ))}
+            </Container>
+          </>
+        )
+      }}
+    </Query>
+  )
+}
+
+export default DistrictOverviewPage

--- a/web/src/queries/gql.js
+++ b/web/src/queries/gql.js
@@ -6,6 +6,7 @@ id
 name_zh
 name_en
 district {
+  dc_code
   dc_name_en
   dc_name_zh
   area_name_en
@@ -68,6 +69,20 @@ export const QUERY_CONSTITUENCY_STATS = gql`
         subtype
         category_1
         category_2
+      }
+    }
+  }
+`
+
+export const QUERY_GET_DISTRICT = gql`
+  query($year: Int!, $code: String!) {
+    dcd_districts( where: { dc_code: { _eq: $code} }) {
+      area_code
+      area_name_zh
+      dc_code
+      dc_name_zh
+      constituencies( where: { year: { _eq: $year } }, order_by: {code: asc} ) {
+        ${CONSTITUENCIES_DATA}
       }
     }
   }

--- a/web/src/utils/helper.js
+++ b/web/src/utils/helper.js
@@ -1,5 +1,7 @@
 export const getDistrictListUriFromTag = tag => `/district/2019/tags/${tag}`
 
+export const getDistrictOverviewUriFromTag = code => `/district/2019/${code}`
+
 /**
  * Passing a councillor object and get the meta data for it
  * (By QUERY_GET_COUNCILLOR_AND_CANDIDATES query)


### PR DESCRIPTION
- Make drawer menu expand all districts in the first area by default (so that show all districts under 香港)
- Add 全XXX區 under each district
- Add a temp district page (e.g. http://localhost:3000/district/2019/A)