### PR TITLE
fix(UIUX): media preview width while fetching

### DIFF
--- a/web/src/components/templates/FCPersonData.js
+++ b/web/src/components/templates/FCPersonData.js
@@ -21,6 +21,12 @@ const Container = styled.div`
   }
 `
 
+const StyledRows = styled(Rows)`
+  && {
+    align-items: normal;
+  }
+`
+
 const StyledButton = styled(Button)`
   && {
     border: 1px black solid;
@@ -69,7 +75,7 @@ const FCPersonData = props => {
           </Typography>
         )}
       </Container>
-      <Rows>
+      <StyledRows>
         {events.map(event => (
           <PersonEvent key={event.eventId} {...event}></PersonEvent>
         ))}
@@ -85,7 +91,7 @@ const FCPersonData = props => {
             </StyledButton>
           </Container>
         )}
-      </Rows>
+      </StyledRows>
     </>
   )
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix media preview width while fetching

* **What is the current behavior?** (You can also link to an open issue here)

the width is shinked

* **What is the new behavior (if this is a feature change)?**

match the width to full-width

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no.

* **Other information**: